### PR TITLE
Add VS Code usage instructions for workflows

### DIFF
--- a/content/docs/workflows.mdx
+++ b/content/docs/workflows.mdx
@@ -7,7 +7,6 @@ icon: "Workflow"
 # **Workflows**
 
 ## What are Workflows?
-
 Workflows are step-by-step automation templates that guide Pochi through complex, multi-step processes. Think of them as detailed recipes that Pochi can follow to complete common development tasks consistently and efficiently.
 
 Key Benefits:
@@ -15,17 +14,11 @@ Key Benefits:
 - Efficiency - Automate repetitive multi-step tasks
 - Knowledge Sharing - Capture team expertise in reusable templates
 
-## How to Use Workflows in VS Code
-
-### Setup
-- Workflows must be in `.pochi/workflows/` directory
-- **Local setup required**: Clone the repository locally to access workflows
-- Use the `/` command for best effici
-
-### Quick Start
-1. **Type `/` in VS Code** to trigger the Pochi workflow selector
-2. **Select a workflow** from the dropdown menu
-3. Pochi executes the workflow automatically
+## Prerequisites
+Before using workflows, you will need:
+- VS Code with Pochi extension installed
+- Local repository setup: Clone the repository locally to access workflows
+- Workflows stored in the `.pochi/workflows/` directory
 
 ## Creating Workflows
 Reusable patterns in `.pochi/workflows/`:
@@ -62,4 +55,12 @@ Please help review a PR using the gh CLI:
 - Submit review using `gh pr review` with appropriate feedback
 
 ```
+## How to Use Workflows in VS Code
+Once your workflows are set up, using them is straightforward:
+1. **Type `/` in VS Code** to trigger the Pochi workflow selector
+2. **Select a workflow** from the dropdown menu
+3. Pochi executes the workflow automatically
+
+For best efficiency and accuracy, always use the `/` command rather than manually describing the workflow steps to Pochi.
+
 


### PR DESCRIPTION
Added missing "How to Use Workflows in VS Code" section as requested by @gyxlucy 

- Instructions for using `/` command
- Setup requirements and local cloning info
- Addresses the Discord question about workflow usage